### PR TITLE
Update x/tools to fix panic in tests with Go 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/tdakkota/asciicheck
 
 go 1.18
 
-require golang.org/x/tools v0.10.0
+require golang.org/x/tools v0.13.0
 
 require (
-	golang.org/x/mod v0.11.0 // indirect
-	golang.org/x/sys v0.9.0 // indirect
+	golang.org/x/mod v0.12.0 // indirect
+	golang.org/x/sys v0.12.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-golang.org/x/mod v0.11.0 h1:bUO06HqtnRcc/7l71XBe4WcqTZ+3AH1J59zWDDwLKgU=
-golang.org/x/mod v0.11.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/mod v0.12.0 h1:rmsUpXtvNzj340zd98LZ4KntptpfRHwpFOHG188oHXc=
+golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
-golang.org/x/sys v0.9.0 h1:KS/R3tvhPqvJvwcKfnBHJwwthS11LRhmM5D59eEXa0s=
-golang.org/x/sys v0.9.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/tools v0.10.0 h1:tvDr/iQoUqNdohiYm0LmmKcBk+q86lb9EprIUFhHHGg=
-golang.org/x/tools v0.10.0/go.mod h1:UJwyiVBsOA2uwvK/e5OY3GTpDUJriEd+/YlqAwLPmyM=
+golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
+golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/tools v0.13.0 h1:Iey4qkscZuv0VvIt8E0neZjtPVQFSc870HQ448QgEmQ=
+golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58=


### PR DESCRIPTION
This PR fixes panic in tests when running with Go 1.23.

<details><summary>Details</summary>
<p>

```
?   	github.com/tdakkota/asciicheck/cmd/asciicheck	[no test files]
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x104781414]

goroutine 159 [running]:
go/types.(*Checker).handleBailout(0x1400012fa40, 0x14000441bb8)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/check.go:404 +0x9c
panic({0x104896820?, 0x104a78660?})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/runtime/panic.go:785 +0x124
go/types.(*StdSizes).Sizeof(0x0, {0x1048e4948, 0x104a7bb60})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/sizes.go:229 +0x314
go/types.(*Config).sizeof(...)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/sizes.go:334
go/types.representableConst.func1({0x1048e4948?, 0x104a7bb60?})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/const.go:77 +0x90
go/types.representableConst({0x1048e5fb8, 0x104a6fd60}, 0x1400012fa40, 0x104a7bb60, 0x140004409d8)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/const.go:93 +0x134
go/types.(*Checker).representation(0x1400012fa40, 0x140004e3740, 0x104a7bb60)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/const.go:257 +0x68
go/types.(*Checker).implicitTypeAndValue(0x1400012fa40, 0x140004e3740, {0x1048e4948, 0x104a7bb60})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/expr.go:377 +0x304
go/types.(*Checker).convertUntyped(0x1400012fa40, 0x140004e3740, {0x1048e4948, 0x104a7bb60})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/const.go:290 +0x30
go/types.(*Checker).matchTypes(0x1400012fa40, 0x140004e3700, 0x140004e3740)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/expr.go:928 +0x7c
go/types.(*Checker).binary(0x1400012fa40, 0x140004e3700, {0x1048e5448, 0x14000620840}, {0x1048e4fc8, 0x140004c2f20}, {0x1048e4ff8, 0x140004c2f40}, 0x28, 0xf25d)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/expr.go:802 +0x114
go/types.(*Checker).exprInternal(0x1400012fa40, 0x0, 0x140004e3700, {0x1048e5448, 0x14000620840}, {0x0, 0x0})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/expr.go:1452 +0x1d4
go/types.(*Checker).rawExpr(0x1400012fa40, 0x0, 0x140004e3700, {0x1048e5448?, 0x14000620840?}, {0x0?, 0x0?}, 0x0)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/expr.go:981 +0x120
go/types.(*Checker).expr(0x1400012fa40, 0x1048e45b0?, 0x140004e3700, {0x1048e5448?, 0x14000620840?})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/expr.go:1549 +0x38
go/types.(*Checker).stmt(0x1400012fa40, 0x0, {0x1048e55c8, 0x140004e29c0})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/stmt.go:579 +0xa3c
go/types.(*Checker).stmtList(0x1400012fa40, 0x0, {0x140004c30a0?, 0x1400012fa40?, 0x3?})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/stmt.go:121 +0x88
go/types.(*Checker).funcBody(0x1400012fa40, 0x1048e4fc8?, {0x1400021c028?, 0x1048e84b8?}, 0x140004e3440, 0x140006208d0, {0x0?, 0x0?})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/stmt.go:41 +0x218
go/types.(*Checker).funcDecl.func1()
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/decl.go:888 +0x44
go/types.(*Checker).processDelayed(0x1400012fa40, 0x0)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/check.go:516 +0x12c
go/types.(*Checker).checkFiles(0x1400012fa40, {0x140004be000, 0x1, 0x1})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/check.go:462 +0x1b4
go/types.(*Checker).Files(0x140001a2000?, {0x140004be000?, 0x1400048ea20?, 0x6?})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/check.go:422 +0x80
golang.org/x/tools/go/packages.(*loader).loadPackage(0x140001a2000, 0x1400009b2c0)
	/Users/Oleksandr_Redko/go/pkg/mod/golang.org/x/tools@v0.10.0/go/packages/packages.go:1055 +0x858
golang.org/x/tools/go/packages.(*loader).loadRecursive.func1()
	/Users/Oleksandr_Redko/go/pkg/mod/golang.org/x/tools@v0.10.0/go/packages/packages.go:854 +0x178
sync.(*Once).doSlow(0x0?, 0x0?)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/sync/once.go:76 +0xf8
sync.(*Once).Do(...)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/sync/once.go:67
golang.org/x/tools/go/packages.(*loader).loadRecursive(0x0?, 0x0?)
	/Users/Oleksandr_Redko/go/pkg/mod/golang.org/x/tools@v0.10.0/go/packages/packages.go:842 +0x48
golang.org/x/tools/go/packages.(*loader).loadRecursive.func1.1(0x0?)
	/Users/Oleksandr_Redko/go/pkg/mod/golang.org/x/tools@v0.10.0/go/packages/packages.go:849 +0x30
created by golang.org/x/tools/go/packages.(*loader).loadRecursive.func1 in goroutine 24
	/Users/Oleksandr_Redko/go/pkg/mod/golang.org/x/tools@v0.10.0/go/packages/packages.go:848 +0x84
FAIL	github.com/tdakkota/asciicheck	0.630s
FAIL

```

</p>
</details> 