### PR TITLE
refactor: remove usage of deprecated ast.Object

### DIFF
--- a/asciicheck.go
+++ b/asciicheck.go
@@ -3,47 +3,41 @@ package asciicheck
 import (
 	"fmt"
 	"go/ast"
+
 	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
 )
 
 func NewAnalyzer() *analysis.Analyzer {
 	return &analysis.Analyzer{
-		Name: "asciicheck",
-		Doc:  "checks that all code identifiers does not have non-ASCII symbols in the name",
-		Run:  run,
+		Name:     "asciicheck",
+		Doc:      "checks that all code identifiers does not have non-ASCII symbols in the name",
+		Requires: []*analysis.Analyzer{inspect.Analyzer},
+		Run:      run,
 	}
 }
 
-func run(pass *analysis.Pass) (interface{}, error) {
-	for _, file := range pass.Files {
-		alreadyViewed := map[*ast.Object]struct{}{}
-		ast.Inspect(
-			file, func(node ast.Node) bool {
-				cb(pass, node, alreadyViewed)
-				return true
-			},
-		)
+func run(pass *analysis.Pass) (any, error) {
+	inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	nodeFilter := []ast.Node{
+		(*ast.Ident)(nil),
 	}
 
-	return nil, nil
-}
-
-func cb(pass *analysis.Pass, n ast.Node, m map[*ast.Object]struct{}) {
-	if v, ok := n.(*ast.Ident); ok {
-		if _, ok := m[v.Obj]; ok {
-			return
-		} else {
-			m[v.Obj] = struct{}{}
-		}
+	inspect.Preorder(nodeFilter, func(n ast.Node) {
+		v := n.(*ast.Ident) // n is always an *ast.Ident because we filter for it
 
 		ch, ascii := isASCII(v.Name)
 		if !ascii {
 			pass.Report(
 				analysis.Diagnostic{
 					Pos:     v.Pos(),
-					Message: fmt.Sprintf("identifier \"%s\" contain non-ASCII character: %#U", v.Name, ch),
+					Message: fmt.Sprintf("identifier %q contain non-ASCII character: %#U", v.Name, ch),
 				},
 			)
 		}
-	}
+	})
+
+	return nil, nil
 }

--- a/testdata/variable_name.go
+++ b/testdata/variable_name.go
@@ -3,7 +3,7 @@ package testdata
 import "fmt"
 
 func f() {
-	var tеstVar int // want `identifier "tеstVar" contain non-ASCII character: U\+0435 'е'`
-	tеstVar = 0
-	fmt.Println(tеstVar)
+	var tеstVar int      // want `identifier "tеstVar" contain non-ASCII character: U\+0435 'е'`
+	tеstVar = 0          // want `identifier "tеstVar" contain non-ASCII character: U\+0435 'е'`
+	fmt.Println(tеstVar) // want `identifier "tеstVar" contain non-ASCII character: U\+0435 'е'`
 }


### PR DESCRIPTION
This PR fixes the failing lint step in CI: https://github.com/tdakkota/asciicheck/actions/runs/13306753820/job/37159392490?pr=27#step:4:28.
It removes usages of the [deprecated](https://github.com/golang/go/issues/52463) `ast.Object`. This is achieved by using the `inspector` package.

The only drawback of using `inspector` is duplicated reported diagnostics, as can be seen in `testdata/variable_name.go`. But I think it's fine, and we can live with it.